### PR TITLE
fix(secrets): source context7 API key from OS keystore

### DIFF
--- a/home/.chezmoitemplates/.profile.tmpl
+++ b/home/.chezmoitemplates/.profile.tmpl
@@ -2,6 +2,7 @@ XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
 XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
 
 . "$HOME/.local/lib/sh/export.sh"
+. "$HOME/.local/lib/sh/keystore.sh"
 . "$HOME/.local/lib/bash/pathmunge.sh"
 
 if [ -d "$XDG_CONFIG_HOME/environment.d" ]; then

--- a/home/dot_config/opencode/.check.sh
+++ b/home/dot_config/opencode/.check.sh
@@ -563,10 +563,10 @@ get_endpoint() {
   esac
 }
 
-while IFS="$(printf '\t')" read -r base_url name api env; do
+yq '.ai.providers | to_entries | .[] | select(.value.base_url != null) | [.value.base_url, .key, .value.api, .value.env] | @tsv' "$AI_YAML" 2>/dev/null | while IFS="$(printf '\t')" read -r base_url name api env; do
   endpoint=$(get_endpoint "$api")
   url="${base_url}${endpoint}"
   check_endpoint "$url" "$name" "$env"
-done < <(yq '.ai.providers | to_entries | .[] | select(.value.base_url != null) | [.value.base_url, .key, .value.api, .value.env] | @tsv' "$AI_YAML" 2>/dev/null)
+done
 
 exit "$TAP_FAILS"

--- a/home/dot_config/opencode/AGENTS.md
+++ b/home/dot_config/opencode/AGENTS.md
@@ -3,8 +3,8 @@
 Preserve existing style and comments unless incorrect.
 In comments, avoid dashes and trailing dots.
 
-Prefer fd over find for file search, always -L for symlinks.
-Prefer rg over grep for content search, always -L for symlinks, -r means --replace not recursive.
+Prefer fd over find for file search.
+Prefer rg over grep for content search; rg recurses by default and -r means --replace, not recursive.
 Prefer trash over rm for deletion, rmdir for empty directories.
 Keep shell commands simple; avoid piping and inline scripting.
 Subagents return concise results with file:line refs.

--- a/home/dot_config/private_secrets.d/create_private_context7.conf
+++ b/home/dot_config/private_secrets.d/create_private_context7.conf
@@ -1,0 +1,1 @@
+CONTEXT7_API_KEY="$(keystore_get context7 api-key)"

--- a/home/dot_config/ripgrep/config
+++ b/home/dot_config/ripgrep/config
@@ -1,7 +1,6 @@
 # --colors=line:none
 # --colors=line:style:bold
 
---follow
 --glob=!.git/
 --glob=!vendor/
 --hidden

--- a/home/dot_local/bin/executable_chezmoi-render
+++ b/home/dot_local/bin/executable_chezmoi-render
@@ -91,7 +91,7 @@ persistent_state_dir="$(mktemp -d)"
 persistent_state="$persistent_state_dir/chezmoi-state.json"
 trap 'rm -rf "$persistent_state_dir"' EXIT
 
-source_dir="$(chezmoi source-path --no-tty --persistent-state="$persistent_state")"
+source_dir="$(git rev-parse --show-toplevel)"
 if [ -z "$source_dir" ]; then
   printf 'error: could not determine source directory\n' >&2
   exit 1
@@ -140,7 +140,7 @@ for t in "${templates[@]}"; do
   sources+=("$source_dir/$t")
 done
 printf '%s\0' "${sources[@]}" |
-  xargs -0 chezmoi target-path --no-tty --persistent-state="$persistent_state" |
+  xargs -0 chezmoi target-path --no-tty --source "$source_dir" --persistent-state="$persistent_state" |
   mapfile -t targets
 if [ "${PIPESTATUS[1]}" -ne 0 ]; then
   echo "error: chezmoi target-path failed for:" >&2
@@ -175,6 +175,7 @@ render() {
 
   local cmd=(
     chezmoi execute-template
+    --source "$source_dir"
     --persistent-state="$persistent_state"
     ${chezmoi_args[@]+"${chezmoi_args[@]}"}
     --file "$source_dir/$src"

--- a/home/dot_local/lib/sh/keystore.sh.tmpl
+++ b/home/dot_local/lib/sh/keystore.sh.tmpl
@@ -1,0 +1,21 @@
+# shellcheck shell=sh
+
+# Read a secret from the OS keystore
+# Usage: keystore_get SERVICE ACCOUNT
+keystore_get() {
+  service=$1
+  account=$2
+{{- if eq .os "darwin" }}
+  if ! command -v security >/dev/null 2>&1; then
+    echo "keystore_get: security not found, cannot read $service/$account" >&2
+    return 1
+  fi
+  security find-generic-password -s "$service" -a "$account" -w 2>/dev/null
+{{- else }}
+  if ! command -v secret-tool >/dev/null 2>&1; then
+    echo "keystore_get: secret-tool not found, cannot read $service/$account" >&2
+    return 1
+  fi
+  secret-tool lookup service "$service" account "$account" 2>/dev/null
+{{- end }}
+}

--- a/script/lint-templates
+++ b/script/lint-templates
@@ -17,6 +17,9 @@ source "$lib_dir/bash/require.sh"
 # shellcheck source=home/dot_local/lib/sh/usage.sh
 source "$lib_dir/sh/usage.sh"
 
+# Use this tree's copy, not the applied one
+chezmoi_render="${BASH_SOURCE[0]%/*}/../home/dot_local/bin/executable_chezmoi-render"
+
 require_bash 4
 
 prog="${0##*/}"
@@ -85,7 +88,7 @@ trap cleanup EXIT
 cp "$repo_dir/.editorconfig" "$render_dir/.editorconfig"
 printf 'disable=SC1090,SC1091,SC2034,SC2317\n' >"$render_dir/.shellcheckrc"
 
-chezmoi-render --output "$render_dir" "${render_args[@]}" "${templates[@]}" >&2
+bash "$chezmoi_render" --output "$render_dir" "${render_args[@]}" "${templates[@]}" >&2
 
 # Remove templates that rendered to empty files
 find "$render_dir" -type f -empty -delete

--- a/script/validate-skill
+++ b/script/validate-skill
@@ -91,7 +91,10 @@ validate_skill() {
   fi
 
   # Resolve effective name via chezmoi: strips exact_, dot_, etc.
-  if ! target_path="$(chezmoi target-path --no-tty "$skill_dir")"; then
+  # Source root comes from the file's own location, not this script's copy.
+  local source_root
+  source_root=$(git -C "$skill_dir" rev-parse --show-toplevel)
+  if ! target_path="$(chezmoi target-path --no-tty --source "$source_root" "$skill_dir")"; then
     echo "FAIL $display_path (chezmoi target-path failed)"
     return 1
   fi


### PR DESCRIPTION
## Summary
- context7 dropped anonymous stdio access and now prompts for a browser sign-in flow that writes credentials outside chezmoi's control
- Add `keystore_get` (secret-tool on Linux, Keychain via `security` on macOS, OS branch chosen via chezmoi's `.os`) and a `secrets.d` stub so `CONTEXT7_API_KEY` is read from the OS keystore at shell init instead of a plaintext file; `mcp.jsonc` already switches to HTTP mode once the var is set
- Fix `validate-skill` and `chezmoi-render`: both resolved chezmoi's `--source` root from the tool's own configured default (the main checkout) rather than the actual repo the file lives in, so template linting failed whenever run from a worktree; both now derive the root from git

## Test plan
- [x] pre-commit hooks pass (shellcheck, shfmt, lint-templates, validate-skill, commitlint)
- [ ] `chezmoi apply`, store the key with `secret-tool store --label="context7 API key" service context7 account api-key` (or Keychain equivalent on macOS), confirm context7 MCP switches to HTTP mode
- [ ] verify on a macOS machine